### PR TITLE
Fixed missing semicolon in enclosed macros

### DIFF
--- a/Log4Cocoa/L4Logging.h
+++ b/Log4Cocoa/L4Logging.h
@@ -35,44 +35,44 @@ LOG4COCOA_EXTERN void log4Log(id object, int line, const char *file, const char 
 #define log4Trace(message, ...)  do{ if([[self l4Logger] isDebugEnabled]){ log4Log(L4_LOG([L4Level trace], nil), message, ##__VA_ARGS__);} }while(0)
 #define log4Debug(message, ...)  do{ if([[self l4Logger] isDebugEnabled]){ log4Log(L4_LOG([L4Level debug], nil), message, ##__VA_ARGS__);} }while(0)
 #define log4Info(message, ...)   do{ if([[self l4Logger] isInfoEnabled]){ log4Log(L4_LOG([L4Level info], nil), message, ##__VA_ARGS__);} }while(0)
-#define log4Warn(message, ...)   do{ log4Log(L4_LOG([L4Level warn], nil), message, ##__VA_ARGS__) }while(0)
-#define log4Error(message, ...)  do{ log4Log(L4_LOG([L4Level error], nil), message, ##__VA_ARGS__) }while(0)
-#define log4Fatal(message, ...)  do{ log4Log(L4_LOG([L4Level fatal], nil), message, ##__VA_ARGS__) }while(0)
+#define log4Warn(message, ...)   do{ log4Log(L4_LOG([L4Level warn], nil), message, ##__VA_ARGS__); }while(0)
+#define log4Error(message, ...)  do{ log4Log(L4_LOG([L4Level error], nil), message, ##__VA_ARGS__); }while(0)
+#define log4Fatal(message, ...)  do{ log4Log(L4_LOG([L4Level fatal], nil), message, ##__VA_ARGS__); }while(0)
 
 
 #pragma mark - Macros that log from C functions
 
 #define log4CDebug(message, ...) do{ if([[[L4FunctionLogger instance] l4Logger] isDebugEnabled]){ log4Log(L4C_LOG([L4Level debug], nil), message, ##__VA_ARGS__);} }while(0)
 #define log4CInfo(message, ...)  do{ if([[[L4FunctionLogger instance] l4Logger] isInfoEnabled]){ log4Log(L4C_LOG([L4Level info], nil), message, ##__VA_ARGS__);} }while(0)
-#define log4CWarn(message, ...)  do{ log4Log(L4C_LOG([L4Level warn], nil), message, ##__VA_ARGS__) }while(0)
-#define log4CError(message, ...) do{ log4Log(L4C_LOG([L4Level error], nil), message, ##__VA_ARGS__) }while(0)
-#define log4CFatal(message, ...) do{ log4Log(L4C_LOG([L4Level fatal], nil), message, ##__VA_ARGS__) }while(0)
+#define log4CWarn(message, ...)  do{ log4Log(L4C_LOG([L4Level warn], nil), message, ##__VA_ARGS__); }while(0)
+#define log4CError(message, ...) do{ log4Log(L4C_LOG([L4Level error], nil), message, ##__VA_ARGS__); }while(0)
+#define log4CFatal(message, ...) do{ log4Log(L4C_LOG([L4Level fatal], nil), message, ##__VA_ARGS__); }while(0)
 
 
 #pragma mark - Macros that log with an exception from objects
 
 #define log4DebugWithException(message, e, ...) do{ if([[self l4Logger] isDebugEnabled]){ log4Log(L4_LOG([L4Level debug], e), message, ##__VA_ARGS__);} }while(0)
 #define log4InfoWithException(message, e, ...)  do{ if([[self l4Logger] isInfoEnabled]){ log4Log(L4_LOG([L4Level info], e), message, ##__VA_ARGS__);} }while(0)
-#define log4WarnWithException(message, e, ...)  do{ log4Log(L4_LOG([L4Level warn], e), message, ##__VA_ARGS__) }while(0)
-#define log4ErrorWithException(message, e, ...) do{ log4Log(L4_LOG([L4Level error], e), message, ##__VA_ARGS__) }while(0)
-#define log4FatalWithException(message, e, ...) do{ log4Log(L4_LOG([L4Level fatal], e), message, ##__VA_ARGS__) }while(0)
+#define log4WarnWithException(message, e, ...)  do{ log4Log(L4_LOG([L4Level warn], e), message, ##__VA_ARGS__); }while(0)
+#define log4ErrorWithException(message, e, ...) do{ log4Log(L4_LOG([L4Level error], e), message, ##__VA_ARGS__); }while(0)
+#define log4FatalWithException(message, e, ...) do{ log4Log(L4_LOG([L4Level fatal], e), message, ##__VA_ARGS__); }while(0)
 
 
 #pragma mark Macros that log with an exception from C functions
 
 #define log4CDebugWithException(message, e, ...) do{ if([[[L4FunctionLogger instance] l4Logger] isDebugEnabled]){ log4Log(L4C_LOG([L4Level debug], e), message, ##__VA_ARGS__);} }while(0)
 #define log4CInfoWithException(message, e, ...)  do{ if([[[L4FunctionLogger instance] l4Logger] isInfoEnabled]){ log4Log(L4C_LOG([L4Level info], e), message, ##__VA_ARGS__);} }while(0)
-#define log4CWarnWithException(message, e, ...)  do{ log4Log(L4C_LOG([L4Level warn], e), message, ##__VA_ARGS__) }while(0)
-#define log4CErrorWithException(message, e, ...) do{ log4Log(L4C_LOG([L4Level error], e), message, ##__VA_ARGS__) }while(0)
-#define log4CFatalWithException(message, e, ...) do{ log4Log(L4C_LOG([L4Level fatal], e), message, ##__VA_ARGS__) }while(0)
+#define log4CWarnWithException(message, e, ...)  do{ log4Log(L4C_LOG([L4Level warn], e), message, ##__VA_ARGS__); }while(0)
+#define log4CErrorWithException(message, e, ...) do{ log4Log(L4C_LOG([L4Level error], e), message, ##__VA_ARGS__); }while(0)
+#define log4CFatalWithException(message, e, ...) do{ log4Log(L4C_LOG([L4Level fatal], e), message, ##__VA_ARGS__); }while(0)
 
 
 #pragma mark - Macro that log when an assertion is false from objects
 
-#define log4Assert(assertion, message, ...) do{ log4Log(L4_ASSERTION(assertion), message, ##__VA_ARGS__) }while(0)
+#define log4Assert(assertion, message, ...) do{ log4Log(L4_ASSERTION(assertion), message, ##__VA_ARGS__); }while(0)
 
 
 #pragma mark - Macro that log when an assertion is false from C functions
 
-#define log4CAssert(assertion, message, ...) do{ log4Log(L4C_ASSERTION(assertion), message, ##__VA_ARGS__) }while(0)
+#define log4CAssert(assertion, message, ...) do{ log4Log(L4C_ASSERTION(assertion), message, ##__VA_ARGS__); }while(0)
 


### PR DESCRIPTION
The enclosing of a macro in a do-while-loop requires the last statement inside to end with a semicolon.
